### PR TITLE
adding option --invert-sg-removal

### DIFF
--- a/fence_vpc.py
+++ b/fence_vpc.py
@@ -87,6 +87,14 @@ def define_new_opts():
         "required": "0",
         "order": 7,
     }
+    all_opt["unfence-ignore-restore"] = {
+        "getopt": "",
+        "longopt": "unfence-ignore-restore",
+        "help": "--unfence-ignore-restore              Do not restore security groups from tag when unfencing (off).",
+        "shortdesc": "Remove all security groups except specified..",
+        "required": "0",
+        "order": 8,
+    }
 
 
 
@@ -111,23 +119,41 @@ def get_instance_id():
 # Retrieve instance details
 def get_instance_details(ec2_client, instance_id):
     """Retrieve instance details including state, VPC, interfaces, and attached SGs."""
-    response = ec2_client.describe_instances(InstanceIds=[instance_id])
-    instance = response["Reservations"][0]["Instances"][0]
+    try:
+        response = ec2_client.describe_instances(InstanceIds=[instance_id])
+        instance = response["Reservations"][0]["Instances"][0]
 
-    instance_state = instance["State"]["Name"]
-    vpc_id = instance["VpcId"]
-    network_interfaces = instance["NetworkInterfaces"]
+        instance_state = instance["State"]["Name"]
+        vpc_id = instance["VpcId"]
+        network_interfaces = instance["NetworkInterfaces"]
 
-    interfaces = []
-    for interface in network_interfaces:
-        interfaces.append(
-            {
-                "NetworkInterfaceId": interface["NetworkInterfaceId"],
-                "SecurityGroups": [sg["GroupId"] for sg in interface["Groups"]],
-            }
-        )
+        interfaces = []
+        for interface in network_interfaces:
+            try:
+                interfaces.append(
+                    {
+                        "NetworkInterfaceId": interface["NetworkInterfaceId"],
+                        "SecurityGroups": [sg["GroupId"] for sg in interface["Groups"]],
+                    }
+                )
+            except KeyError as e:
+                logger.error(f"Malformed interface data: {str(e)}")
+                continue
 
-    return instance_state, vpc_id, interfaces
+        return instance_state, vpc_id, interfaces
+
+    except ClientError as e:
+        logger.error(f"AWS API error while retrieving instance details: {str(e)}")
+        raise
+    except IndexError as e:
+        logger.error(f"Instance {instance_id} not found or no instances returned: {str(e)}")
+        raise
+    except KeyError as e:
+        logger.error(f"Unexpected response format from AWS API: {str(e)}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error while retrieving instance details: {str(e)}")
+        raise
 
 # Check if we are the self-fencing node 
 
@@ -152,14 +178,22 @@ def get_self_power_status(conn, instance_id):
 # Create a backup tag
 def create_backup_tag(ec2_client, instance_id, interfaces):
     """Create a tag on the instance to backup original security groups."""
-    sg_backup = {"NetworkInterfaces": interfaces}
-    tag_value = json.dumps(sg_backup)
+    try:
+        sg_backup = {"NetworkInterfaces": interfaces}
+        tag_value = json.dumps(sg_backup)
 
-    ec2_client.create_tags(
-        Resources=[instance_id],
-        Tags=[{"Key": "Original_SG_Backup", "Value": tag_value}],
-    )
-    logger.info(f"Backup tag 'Original_SG_Backup' created for instance {instance_id}.")
+        tag_key = f"Original_SG_Backup_{instance_id}"
+        ec2_client.create_tags(
+            Resources=[instance_id],
+            Tags=[{"Key": tag_key, "Value": tag_value}],
+        )
+        logger.info(f"Backup tag '{tag_key}' created for instance {instance_id}.")
+    except ClientError as e:
+        logger.error(f"AWS API error while creating backup tag: {str(e)}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error while creating backup tag: {str(e)}")
+        raise
 
 
 # Remove specified security groups
@@ -167,126 +201,304 @@ def remove_security_groups(ec2_client, instance_id, sg_list):
     """
     Removes all SGs in `sg_list` from each interface, if it doesn't leave zero SGs.
     If no changes are made to any interface, we exit with an error.
-    """
-    state, _, interfaces = get_instance_details(ec2_client, instance_id)
-
-    # Create a backup tag before making changes
-    create_backup_tag(ec2_client, instance_id, interfaces)
-
-    changed_any = False
-    for interface in interfaces:
-        original_sgs = interface["SecurityGroups"]
-        # Exclude any SGs that are in sg_list
-        updated_sgs = [sg for sg in original_sgs if sg not in sg_list]
-
-        #print(sg_list)
-
-        # If there's no change or we'd end up with zero SGs, skip
-        if updated_sgs == original_sgs:
-            continue
-        if not updated_sgs:
-            print(
-                f"Skipping interface {interface['NetworkInterfaceId']}: "
-                f"removal of {sg_list} would leave 0 SGs."
-            )
-            continue
-
-        print(
-            f"Updating interface {interface['NetworkInterfaceId']} from {original_sgs} "
-            f"to {updated_sgs} (removing {sg_list})"
-        )
-        ec2_client.modify_network_interface_attribute(
-            NetworkInterfaceId=interface["NetworkInterfaceId"],
-            Groups=updated_sgs
-        )
-        changed_any = True
-
-    # If we didn't remove anything, either the SGs weren't found or it left 0 SG
-    if not changed_any:
-        print(
-            f"Security Groups {sg_list} not removed from any interface. "
-            f"Either not found, or removal left 0 SGs."
-        )
-        sys.exit(1)
-
-    # Wait a bit for changes to propagate
-    time.sleep(5)
-
-def keep_only_security_groups(ec2_client, instance_id, sg_to_keep_list):
-    """
-    Removes all security groups from each network interface except for the specified one.
-    If the specified security group is not attached to an interface, that interface is skipped.
     
     Args:
         ec2_client: The boto3 EC2 client
         instance_id: The ID of the EC2 instance
-        sg_to_keep_list: List containing the ID of the security group to keep
+        sg_list: List of security group IDs to remove
+        
+    Raises:
+        ClientError: If AWS API calls fail
+        Exception: For other unexpected errors
     """
-    state, _, interfaces = get_instance_details(ec2_client, instance_id)
-
-    # Create a backup tag before making changes
-    create_backup_tag(ec2_client, instance_id, interfaces)
-
-    changed_any = False
-    for interface in interfaces:
-        original_sgs = interface["SecurityGroups"]
+    try:
+        # Get instance details
+        state, _, interfaces = get_instance_details(ec2_client, instance_id)
         
-        # Skip if the security group to keep isn't attached to this interface
+        try:
+            # Create a backup tag before making changes
+            create_backup_tag(ec2_client, instance_id, interfaces)
+        except ClientError as e:
+            logger.warning(f"Failed to create backup tag: {str(e)}")
+            # Continue execution even if backup tag creation fails
+        
+        changed_any = False
+        for interface in interfaces:
+            try:
+                original_sgs = interface["SecurityGroups"]
+                # Exclude any SGs that are in sg_list
+                updated_sgs = [sg for sg in original_sgs if sg not in sg_list]
 
-        #str(list1).replace('[','').replace(']','')
-        #if sg_to_keep not in original_sgs:
-        # Check if any of the security groups to keep are attached
-        sgs_to_keep = [sg for sg in original_sgs if sg in sg_to_keep_list]
-        if not sgs_to_keep:
-            print(
-                f"Skipping interface {interface['NetworkInterfaceId']}: "
-                f"none of the security groups {sg_to_keep_list} are attached."
+                # If there's no change or we'd end up with zero SGs, skip
+                if updated_sgs == original_sgs:
+                    continue
+                if not updated_sgs:
+                    logger.info(
+                        f"Skipping interface {interface['NetworkInterfaceId']}: "
+                        f"removal of {sg_list} would leave 0 SGs."
+                    )
+                    continue
+
+                logger.info(
+                    f"Updating interface {interface['NetworkInterfaceId']} from {original_sgs} "
+                    f"to {updated_sgs} (removing {sg_list})"
+                )
+                
+                try:
+                    ec2_client.modify_network_interface_attribute(
+                        NetworkInterfaceId=interface["NetworkInterfaceId"],
+                        Groups=updated_sgs
+                    )
+                    changed_any = True
+                except ClientError as e:
+                    logger.error(
+                        f"Failed to modify security groups for interface "
+                        f"{interface['NetworkInterfaceId']}: {str(e)}"
+                    )
+                    continue
+                    
+            except KeyError as e:
+                logger.error(f"Malformed interface data: {str(e)}")
+                continue
+
+        # If we didn't remove anything, either the SGs weren't found or it left 0 SG
+        if not changed_any:
+            logger.error(
+                f"Security Groups {sg_list} not removed from any interface. "
+                f"Either not found, or removal left 0 SGs."
             )
-            continue
+            sys.exit(1)
 
-        # Set interface to only use the specified security groups
-        updated_sgs = sgs_to_keep
+        # Wait a bit for changes to propagate
+        time.sleep(5)
         
-        if updated_sgs == original_sgs:
-            continue
+    except ClientError as e:
+        logger.error(f"AWS API error: {str(e)}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        raise
 
-        print(
-            f"Updating interface {interface['NetworkInterfaceId']} from {original_sgs} "
-            f"to {updated_sgs} (keeping only {sg_to_keep_list})"
+def keep_only_security_groups(ec2_client, instance_id, sg_to_keep_list):
+    """
+    Removes all security groups from each network interface except for the specified ones.
+    If none of the specified security groups are attached to an interface, that interface is skipped.
+    
+    Args:
+        ec2_client: The boto3 EC2 client
+        instance_id: The ID of the EC2 instance
+        sg_to_keep_list: List containing the IDs of the security groups to keep
+        
+    Raises:
+        ClientError: If AWS API calls fail
+        Exception: For other unexpected errors
+    """
+    try:
+        state, _, interfaces = get_instance_details(ec2_client, instance_id)
+
+        try:
+            # Create a backup tag before making changes
+            create_backup_tag(ec2_client, instance_id, interfaces)
+        except ClientError as e:
+            logger.warning(f"Failed to create backup tag: {str(e)}")
+            # Continue execution even if backup tag creation fails
+
+        changed_any = False
+        for interface in interfaces:
+            try:
+                original_sgs = interface["SecurityGroups"]
+                
+                # Check if any of the security groups to keep are attached
+                sgs_to_keep = [sg for sg in original_sgs if sg in sg_to_keep_list]
+                if not sgs_to_keep:
+                    logger.info(
+                        f"Skipping interface {interface['NetworkInterfaceId']}: "
+                        f"none of the security groups {sg_to_keep_list} are attached."
+                    )
+                    continue
+
+                # Set interface to only use the specified security groups
+                updated_sgs = sgs_to_keep
+                
+                if updated_sgs == original_sgs:
+                    continue
+
+                logger.info(
+                    f"Updating interface {interface['NetworkInterfaceId']} from {original_sgs} "
+                    f"to {updated_sgs} (keeping only {sg_to_keep_list})"
+                )
+                
+                try:
+                    ec2_client.modify_network_interface_attribute(
+                        NetworkInterfaceId=interface["NetworkInterfaceId"],
+                        Groups=updated_sgs
+                    )
+                    changed_any = True
+                except ClientError as e:
+                    logger.error(
+                        f"Failed to modify security groups for interface "
+                        f"{interface['NetworkInterfaceId']}: {str(e)}"
+                    )
+                    continue
+                    
+            except KeyError as e:
+                logger.error(f"Malformed interface data: {str(e)}")
+                continue
+
+        # If we didn't modify anything, the specified SGs weren't found on any interface
+        if not changed_any:
+            logger.error(
+                f"Security Groups {sg_to_keep_list} not found on any interface. "
+                f"No changes made."
+            )
+            sys.exit(1)
+
+        # Wait a bit for changes to propagate
+        time.sleep(5)
+        
+    except ClientError as e:
+        logger.error(f"AWS API error: {str(e)}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        raise
+
+def restore_security_groups(ec2_client, instance_id):
+    """
+    Restores the original security groups from the backup tag to each network interface.
+    
+    Args:
+        ec2_client: The boto3 EC2 client
+        instance_id: The ID of the EC2 instance
+        
+    Raises:
+        ClientError: If AWS API calls fail
+        Exception: For other unexpected errors
+    """
+    try:
+        # Get the backup tag
+        response = ec2_client.describe_tags(
+            Filters=[
+                {"Name": "resource-id", "Values": [instance_id]},
+                {"Name": "key", "Values": [f"Original_SG_Backup_{instance_id}"]}
+            ]
         )
-        ec2_client.modify_network_interface_attribute(
-            NetworkInterfaceId=interface["NetworkInterfaceId"],
-            Groups=updated_sgs
-        )
-        changed_any = True
-
-    # If we didn't modify anything, the specified SG wasn't found on any interface
-    if not changed_any:
-        print(
-            f"Security Groups {sg_to_keep_list} not found on any interface. "
-            f"No changes made."
-        )
-        sys.exit(1)
-
-    # Wait a bit for changes to propagate
-    time.sleep(5)
-
-
+        
+        if not response["Tags"]:
+            logger.error(f"No backup tag found for instance {instance_id}")
+            sys.exit(1)
+            
+        try:
+            backup_data = json.loads(response["Tags"][0]["Value"])
+            backup_interfaces = backup_data["NetworkInterfaces"]
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(f"Failed to parse backup data: {str(e)}")
+            sys.exit(1)
+            
+        # Get current interfaces
+        _, _, current_interfaces = get_instance_details(ec2_client, instance_id)
+        
+        # Create a map of interface IDs to their backup security groups
+        backup_sg_map = {
+            interface["NetworkInterfaceId"]: interface["SecurityGroups"]
+            for interface in backup_interfaces
+        }
+        
+        changed_any = False
+        for interface in current_interfaces:
+            try:
+                interface_id = interface["NetworkInterfaceId"]
+                if interface_id not in backup_sg_map:
+                    logger.warning(
+                        f"No backup data found for interface {interface_id}. Skipping."
+                    )
+                    continue
+                    
+                original_sgs = backup_sg_map[interface_id]
+                current_sgs = interface["SecurityGroups"]
+                
+                if original_sgs == current_sgs:
+                    logger.info(
+                        f"Interface {interface_id} already has original security groups. Skipping."
+                    )
+                    continue
+                
+                logger.info(
+                    f"Restoring interface {interface_id} from {current_sgs} "
+                    f"to original security groups {original_sgs}"
+                )
+                
+                try:
+                    ec2_client.modify_network_interface_attribute(
+                        NetworkInterfaceId=interface_id,
+                        Groups=original_sgs
+                    )
+                    changed_any = True
+                except ClientError as e:
+                    logger.error(
+                        f"Failed to restore security groups for interface "
+                        f"{interface_id}: {str(e)}"
+                    )
+                    continue
+                    
+            except KeyError as e:
+                logger.error(f"Malformed interface data: {str(e)}")
+                continue
+                
+        if not changed_any:
+            logger.error("No security groups were restored. All interfaces skipped.")
+            sys.exit(1)
+            
+        # Wait for changes to propagate
+        time.sleep(5)
+        
+        # Clean up the backup tag
+        try:
+            ec2_client.delete_tags(
+                Resources=[instance_id],
+                Tags=[{"Key": f"Original_SG_Backup_{instance_id}"}]
+            )
+            logger.info(f"Removed backup tag from instance {instance_id}")
+        except ClientError as e:
+            logger.warning(f"Failed to remove backup tag: {str(e)}")
+            # Continue since the restore operation was successful
+            
+    except ClientError as e:
+        logger.error(f"AWS API error: {str(e)}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error: {str(e)}")
+        raise
 
 # Shutdown instance
 def shutdown_instance(ec2_client, instance_id):
     """Shutdown the instance and confirm the state transition."""
-    logger.info(f"Initiating shutdown for instance {instance_id}...")
-    ec2_client.stop_instances(InstanceIds=[instance_id], Force=True)
+    try:
+        logger.info(f"Initiating shutdown for instance {instance_id}...")
+        ec2_client.stop_instances(InstanceIds=[instance_id], Force=True)
+ 
+        while True:
+            try:
+                state, _, _ = get_instance_details(ec2_client, instance_id)
+                logger.info(f"Current instance state: {state}")
+                if state == "stopping":
+                    logger.info(
+                        f"Instance {instance_id} is transitioning to 'stopping'. Proceeding without waiting further."
+                    )
+                    break
+            except ClientError as e:
+                logger.error(f"Failed to get instance state during shutdown: {str(e)}")
+                fail_usage(f"AWS API error while checking instance state: {str(e)}")
+            except Exception as e:
+                logger.error(f"Unexpected error while checking instance state: {str(e)}")
+                fail_usage(f"Failed to check instance state: {str(e)}")
 
-    while True:
-        state, _, _ = get_instance_details(ec2_client, instance_id)
-        logger.info(f"Current instance state: {state}")
-        if state == "stopping":
-            logger.info(
-                f"Instance {instance_id} is transitioning to 'stopping'. Proceeding without waiting further."
-            )
-            break
+    except ClientError as e:
+        logger.error(f"AWS API error during instance shutdown: {str(e)}")
+        fail_usage(f"Failed to shutdown instance: {str(e)}")
+    except Exception as e:
+        logger.error(f"Unexpected error during instance shutdown: {str(e)}")
+        fail_usage(f"Failed to shutdown instance due to unexpected error: {str(e)}")
 
 
 # Perform the fencing action
@@ -311,13 +523,21 @@ def fence_vpc_action(conn, options):
         fail_usage(f"Instance {instance_id} is not running. Exiting.")
 
     # Remove security groups (if provided) and shutdown the instance
-    if sg_to_remove:
-        if "--invert-sg-removal" not in options:
-            remove_security_groups(ec2_client, instance_id, sg_to_remove)
+    if (options["--action"]=="off"):
+        if not "--unfence-ignore-restore" in options:
+            restore_security_groups(ec2_client, instance_id)
         else:
-            keep_only_security_groups(ec2_client, instance_id, sg_to_remove)
+            print("Ignored Restoring security groups as --unfence-ignore-restore is set")
+    elif (options["--action"]=="on"):
+        if sg_to_remove:
+            if "--invert-sg-removal" not in options:
+                remove_security_groups(ec2_client, instance_id, sg_to_remove)
+                #shutdown_instance(ec2_client, instance_id)
+            else:
+                keep_only_security_groups(ec2_client, instance_id, sg_to_remove)
+                #shutdown_instance(ec2_client, instance_id)
 
-        #shutdown_instance(ec2_client, instance_id)
+
 
 
 # Main function
@@ -330,7 +550,8 @@ def main():
         "sg",
         "plug",
         "skip_race_check",
-        "invert-sg-removal"
+        "invert-sg-removal",
+        "unfence-ignore-restore"
     ]
 
 


### PR DESCRIPTION
added the option for --invert-sg-removal and the neccessary code to do this, when this option is defined the list of SG(s) specified - comma separated in teh command line options for --g will be the only SG(sg) left attached to teh resource.

all the appropriate checking to ensure there is always one sg left on the instance in the fucntion.

Slection logic for wether the option is on or off has been implemeted.

aligned the options so skip did the right thing